### PR TITLE
Enhance SVG helper tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gem 'middleman-sitemap',       '~> 0.0.13'
 gem 'middleman-sitemap-ping',  '~> 0.0.2'
 
 gem 'slim',                    '~> 3.0.2'
+gem 'oga',                     '~> 2.8'

--- a/helpers/svg_helper.rb
+++ b/helpers/svg_helper.rb
@@ -1,8 +1,11 @@
+require 'lib/svg'
+
 module SvgHelper
-  def svg(name)
-    root = Middleman::Application.root
-    file_path = "#{root}/source/assets/images/svg/#{name}.svg"
-    return File.read(file_path) if File.exists?(file_path)
-    '(not found)'
+  def svg_tag(filename, options={})
+    root      = Middleman::Application.root
+    file_path = File.join(root, 'source', config[:images_dir], filename)
+    return '(SVG img not found)' unless File.exists?(file_path)
+
+    SVG.inline(file_path, options)
   end
 end

--- a/lib/svg.rb
+++ b/lib/svg.rb
@@ -1,0 +1,90 @@
+# [Imported from http://github.com/cveneziani/middleman-boilerplate/]
+require 'oga'
+
+# SVG file inliner
+#
+# Examples
+#
+#   SVG.inline('images/square.svg', class: 'logo', alt: 'Website logo')
+#   # => "<svg role="img" aria-label="Website logo" class="logo"
+#          width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+#           <desc>Website logo</desc>
+#           <path d="M10 10 H 90 V 90 H 10 L 10 10"/>
+#         </svg>"
+class SVG
+  private
+
+  attr_reader :file_path, :options
+
+  public
+
+  # Public: Convert a SVG file into an inline version
+  #
+  # file_path - The file path of the SVG file
+  # options   - Hash of options (default: {})
+  #             :class - String for any class(es) to be applied to the `svg` tag
+  #                      Override any existing class value.
+  #             :alt   - String used to add accessibility and SEO to the SVG
+  #                      - Set `role="img"` and `aria-label` attributes
+  #                      - Add a `desc` element
+  #
+  # Examples
+  #
+  #   SVG.inline('images/square.svg')
+  #   # => "<svg class="default-class" width="100" height="100"
+  #          xmlns="http://www.w3.org/2000/svg">
+  #           <path d="M10 10 H 90 V 90 H 10 L 10 10"/>
+  #         </svg>"
+  #   SVG.inline('images/square.svg', class: 'logo', alt: 'Website logo')
+  #   # => "<svg role="img" aria-label="Website logo" class="logo"
+  #          width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+  #           <desc>Website logo</desc>
+  #           <path d="M10 10 H 90 V 90 H 10 L 10 10"/>
+  #         </svg>"
+  #
+  # Returns the inlined SVG as a String
+  def self.inline(file_path, options={})
+    new(file_path, options).inline
+  end
+
+  def initialize(file_path, options={})
+    @file_path = file_path
+    @options   = options
+  end
+
+  # Public: See doc of .inline method.
+  def inline
+    return read_file if options.empty?
+    inline_with_options
+  end
+
+  private
+
+  def inline_with_options
+    document        = Oga.parse_xml(File.open(file_path))
+    svg             = document.css('svg').first
+
+    svg.set('role', 'img')
+
+    apply_class_option(svg) if options[:class]
+    apply_alt_option(svg)   if options[:alt]
+
+    document.to_xml
+  end
+
+  def apply_alt_option(svg)
+    desc            = Oga::XML::Element.new(name: :desc)
+    desc.inner_text = options[:alt]
+
+    svg.set('aria-label', options[:alt])
+    svg.children << desc
+  end
+
+  def apply_class_option(svg)
+    svg.set(:class, options[:class])
+  end
+
+  def read_file
+    File.read(file_path)
+  end
+end


### PR DESCRIPTION
In this pull request, I propose 3 things :

- Rename `svg` helper into `svg_tag` so that we keep a naming consistency with `image_tag`
- Add `:class` option to directly specify a class on the `svg` tag
- Add `:alt` option to add `role="img"`, `aria-label` attributes on `svg` tag + add `desc` tag

## Implementation details

I had to add a dependency to an XML parser, in order to be able to add a `class` attribute and a `desc` tag to the svg tag. 

I chose to add [oga]() instead of Nokogiri for the following reasons:
- it's a small library (2.5Mb for oga VS 23Mb for nokogiri)
- it's much faster to install (just crazy how lonk nokogiri is)

## Examples

I've tried to add a SVG image on the homepage. Here are the results:

### Raw SVG

Added with `svg_tag "logo.svg"`
![svg-raw](https://cloud.githubusercontent.com/assets/50518/21702145/18fcbaba-d3aa-11e6-91b5-e9b1087ac627.png)

### SVG with options

Added with `svg_tag 'svg/logo.svg', class: 'logo', alt: "Website Logo"`

And the following CSS rules:

```css
body {
  background-color: #80C9D6;
}

.logo {
  height: 25em;
  max-width: 100%;

  .svg-path {
    fill-opacity: 1;
    fill: white;
    stroke: #555;
  }
}
```

![svg-styled-with-css](https://cloud.githubusercontent.com/assets/50518/21702173/501f566a-d3aa-11e6-9b62-edd45549cc83.png)

And the resulting accessibility attributes and SEO tag generated:

![svg-desc-tag](https://cloud.githubusercontent.com/assets/50518/21702184/67562bf6-d3aa-11e6-970b-c0848b65e0e5.png)

I've extracted this implementation from https://github.com/cveneziani/middleman-boilerplate