### PR TITLE
Bump rvm version to 2.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.3.1
+  - 2.3.4
 cache:
   - bundler
 branches:


### PR DESCRIPTION
Noticed travis.yml did not reflect the project ruby bump to 2.3.4